### PR TITLE
Added variables to configure Virtualbox provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ workers you want in the `Vagrantfile`, by setting the `numworkers` variable. Man
 numworkers = 2
 ```
 
+If your provisioner is `Virtualbox`, you can modify the vm allocations for memory and cpu by changing these variables:
+
+```ruby
+vmmemory = 512
+```
+
+```ruby
+numcpu = 1
+```
+
+
 `/etc/hosts` on every machine is populated with an IP address and a name of every other machine, so that names are resolved within the cluster. This mechanism is not idempotent, reprovisioning will append the hosts again. 
 
 # Auto mode

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,14 @@
 # you're doing.
 
 auto = ENV['AUTO_START_SWARM'] || false
+# Increase numworkers if you want more than 3 nodes
 numworkers = 2
+
+# VirtualBox settings
+# Increase vmmemory if you want more than 512mb memory in the vm's
+vmmemory = 512
+# Increase numcpu if you want more cpu's per vm
+numcpu = 1
 
 instances = []
 
@@ -24,6 +31,10 @@ File.open("./hosts", 'w') { |file|
 }
 
 Vagrant.configure("2") do |config|
+    config.vm.provider "virtualbox" do |v|
+     	v.memory = vmmemory
+  	v.cpus = numcpu
+    end
     
     config.vm.define "manager" do |i|
       i.vm.box = "ubuntu/trusty64"


### PR DESCRIPTION
Thanks for this swarm vagrant! I have been learning docker and having this available to me was very beneficial.

I added variables for cpu and memory settings that work if using virtualbox.  This is needed to have vm's with the > 512mb default.  Depending on the docker images being used, 512mb very likely will be too little memory, so this provides a quick way to increase the memory allocation and/or # cpu's in a vm.

I also updated the documentation regarding these new settings.  
