### PR TITLE
Add alternative files for installing Docker 18.09 in Xenial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+synced/
+hosts
+*.log
+.vagrant/
+
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This is a simple Vagrantfile which can be used to spin few nodes with Docker 1.12+ installed. You
 can play with Docker Swarm on it. Boxes are Ubuntu Trusty amd64. 
 
+*Note*: This fork updates the original in providing two additional files, Vagrantefile.XENIAL and provision.sh.XENIAL. Replace the originals with these files if you wish to run a newer version of Docker in the Xenial version of Ubuntu. There is an issue with Docker Swarm when using the original files. See this:
+
+[https://github.com/moby/moby/issues/34165]
+
+So far as I have seen, using the Xenial versions of the files to create and provision the Vagrant nodes fixes this problem.
+
 # Docker Swarm
 
 Docker Swarm is a Docker clustering solution, it turns multiple physical (or virtual) hosts into a one cluster, which practically behaves as a single Docker host. Swarm additionally gives you tools and mechiasms to easily scale your containers and create managed services with automatic load balancing to the exposed ports. 

--- a/Vagrantfile.XENIAL
+++ b/Vagrantfile.XENIAL
@@ -1,0 +1,121 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+
+auto = ENV['AUTO_START_SWARM'] || false
+# Increase numworkers if you want more than 3 nodes
+numworkers = 2
+
+# VirtualBox settings
+# Increase vmmemory if you want more than 512mb memory in the vm's
+vmmemory = 2048
+# Increase numcpu if you want more cpu's per vm
+numcpu = 1
+
+instances = []
+
+(1..numworkers).each do |n| 
+  instances.push({:name => "worker#{n}", :ip => "192.168.10.#{n+2}"})
+end
+
+manager_ip = "192.168.10.2"
+
+File.open("./hosts", 'w') { |file| 
+  instances.each do |i|
+    file.write("#{i[:ip]} #{i[:name]} #{i[:name]}\n")
+  end
+}
+
+http_proxy = ""
+# Proxy configuration
+if ENV['http_proxy']
+	http_proxy = ENV['http_proxy']
+	https_proxy = ENV['https_proxy']
+end
+
+no_proxy = "localhost,127.0.0.1,#{manager_ip}"
+instances.each do |instance|
+    no_proxy += ",#{instance[:ip]}"
+end
+
+# Vagrant version requirement
+Vagrant.require_version ">= 1.8.4"
+
+# Check if the necessary plugins are installed
+if not http_proxy.to_s.strip.empty?
+	required_plugins = %w( vagrant-proxyconf )
+	plugins_to_install = required_plugins.select { |plugin| not Vagrant.has_plugin? plugin }
+	if not plugins_to_install.empty?
+    	puts "Installing plugins: #{plugins_to_install.join(' ')}"
+    	if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+        	exec "vagrant #{ARGV.join(' ')}"
+    	else
+        	abort "Installation of one or more plugins has failed. Aborting."
+    	end
+	end
+end
+
+Vagrant.configure("2") do |config|
+    config.vm.provider "virtualbox" do |v|
+     	v.memory = vmmemory
+  	v.cpus = numcpu
+    end
+    
+    config.vm.define "manager" do |i|
+      i.vm.box = "ubuntu/xenial64"
+      i.vm.box_url = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-vagrant.box"
+      i.vm.hostname = "manager"
+      i.vm.network "private_network", ip: "#{manager_ip}"
+      i.vm.network "forwarded_port", guest:2375, host:2375
+      i.vm.network "forwarded_port", guest:2376, host:2376
+      i.vm.network "forwarded_port", guest:8080, host:8080
+      i.vm.network "forwarded_port", guest:8081, host:8081
+      i.vm.network "forwarded_port", guest:8082, host:8082
+      i.vm.network "forwarded_port", guest:8083, host:8083
+      i.vm.network "forwarded_port", guest:8084, host:8084
+      i.vm.network "forwarded_port", guest:8085, host:8085
+      i.vm.synced_folder "synced/manager", "/data"
+      # Proxy
+      if not http_proxy.to_s.strip.empty?
+        i.proxy.http     = http_proxy
+        i.proxy.https    = https_proxy
+        i.proxy.no_proxy = no_proxy
+      end
+      i.vm.provision "shell", path: "./provision.sh"
+      if File.file?("./hosts") 
+        i.vm.provision "file", source: "hosts", destination: "/tmp/hosts"
+        i.vm.provision "shell", inline: "cat /tmp/hosts >> /etc/hosts", privileged: true
+      end 
+      if auto 
+        i.vm.provision "shell", inline: "docker swarm init --advertise-addr #{manager_ip}"
+        i.vm.provision "shell", inline: "docker swarm join-token -q worker > /vagrant/token"
+      end
+    end 
+
+  instances.each do |instance| 
+    config.vm.define instance[:name] do |i|
+      i.vm.box = "ubuntu/xenial64"
+      i.vm.box_url = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-vagrant.box"
+      i.vm.hostname = instance[:name]
+      i.vm.network "private_network", ip: "#{instance[:ip]}"
+      # Proxy
+      if not http_proxy.to_s.strip.empty?
+        i.proxy.http     = http_proxy
+        i.proxy.https    = https_proxy
+        i.proxy.no_proxy = no_proxy
+      end
+      i.vm.provision "shell", path: "./provision.sh"
+      if File.file?("./hosts") 
+        i.vm.provision "file", source: "hosts", destination: "/tmp/hosts"
+        i.vm.provision "shell", inline: "cat /tmp/hosts >> /etc/hosts", privileged: true
+      end 
+      if auto
+        i.vm.provision "shell", inline: "docker swarm join --advertise-addr #{instance[:ip]} --listen-addr #{instance[:ip]}:2377 --token `cat /vagrant/token` #{manager_ip}:2377"
+      end
+    end 
+  end
+end

--- a/provision.sh.XENIAL
+++ b/provision.sh.XENIAL
@@ -1,0 +1,41 @@
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+
+#sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 \ --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+#echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
+#sudo apt-get update
+## sudo apt-get install linux-image-extra-$(uname -r) linux-image-extra-virtual -y
+#sudo apt-get install docker-engine --force-yes -y
+#sudo usermod -aG docker vagrant
+#sudo service docker start
+#docker version
+
+sudo apt-get update -y -qq
+
+sudo apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg-agent \
+  software-properties-common
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+sudo apt-get update -y -qq
+
+#The following fails on docker-ce-cli, "package not found"
+#sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+#It looks like this is all that's needed...maybe
+sudo apt-get install -y docker-ce
+
+sudo usermod -aG docker vagrant
+
+#sudo service docker start
+
+


### PR DESCRIPTION
For your consideration. I opened an issue earlier and it came back. In the end, the problem was a bug in Docker 17.03, which was what I was getting installed in Trusty. This led to random "No route to host" errors in Docker Swarm nodes. My changes add Vagrantfile.XENIAL and provision.sh.XENIAL, which can replace the originals. This allows users to install a newer version of Docker, which in turn requires a newer Linux kernel, and Xenial does that.

There are a few other tweaks in the new Vagrantfile. 1) It forwards 8080-8085, so that any service running in the nodes will automatically be able to publish to those ports. 2) It syncs a path, synced/manager, which the end user would have to create, or else take out the sync definition. I did this so that I can place other files there that are accessible within the manager node, for deploying stacks, for example.

Also created a .gitignore and added a note about all of this to the README.